### PR TITLE
documentation for r_na and r_dummy.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: wakefield
 Title: Generate Random Data Sets
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(person("Tyler", "Rinker", email =
         "tyler.rinker@gmail.com", role = c("aut", "cre")),
         person("Josh", "O'Brien", role = "ctb"), person("Ananda",
@@ -12,7 +12,7 @@ Description: Generates random data sets including: data.frames, lists,
 Depends: R (>= 3.1.2)
 Imports: chron, ggplot2, dplyr, stringi
 Suggests: testthat
-Date: 2017-04-14
+Date: 2017-06-06
 License: GPL-2
 LazyData: TRUE
 URL: https://github.com/trinker/wakefield

--- a/R/r_dummy.R
+++ b/R/r_dummy.R
@@ -1,12 +1,12 @@
-#' Title
+#' Generate Random Dummy Values
 #'
-#' Description
+#' Generate random values from a \pkg{wakefield} variable function.
 #'
 #' @param fun A \pkg{wakefield} variable function.
 #' @param n The number of rows to produce.
 #' @param \ldots Additional arguments passed to \code{fun}.
 #' @param prefix logical.  If \code{TRUE} the original factor name (supplied to
-#' \code{fun} as \code{name} argument) will prefic the column names that were
+#' \code{fun} as \code{name} argument) will prefix the column names that were
 #' generated from the factor's categories.
 #' @param rep.sep A separator to use for the variable and category part of names
 #' when \code{prefix = TRUE}.  For example if the \code{\link[wakefield]{age}}

--- a/R/r_na.R
+++ b/R/r_na.R
@@ -1,6 +1,6 @@
-#' Title
+#' Replace a Proportion of Values With NA
 #'
-#' Description
+#' Replaces a proportion of values with NA. Useful for simulating missing data.
 #'
 #' @param x A \code{\link[base]{data.frame}} or \code{\link[base]{list}} to
 #' randomly replace elements with \code{NA}s.

--- a/man/r_dummy.Rd
+++ b/man/r_dummy.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/r_dummy.R
 \name{r_dummy}
 \alias{r_dummy}
-\title{Title}
+\title{Generate Random Dummy Values}
 \usage{
 r_dummy(fun, n, ..., prefix = FALSE, rep.sep = "_")
 }
@@ -12,7 +12,7 @@ r_dummy(fun, n, ..., prefix = FALSE, rep.sep = "_")
 \item{n}{The number of rows to produce.}
 
 \item{prefix}{logical.  If \code{TRUE} the original factor name (supplied to
-\code{fun} as \code{name} argument) will prefic the column names that were
+\code{fun} as \code{name} argument) will prefix the column names that were
 generated from the factor's categories.}
 
 \item{rep.sep}{A separator to use for the variable and category part of names
@@ -26,7 +26,7 @@ is used (\code{r_dummy(sex)}), this results in column names
 Returns a \code{\link[dplyr]{tbl_df}}.
 }
 \description{
-Description
+Generate random values from a \pkg{wakefield} variable function.
 }
 \examples{
 r_dummy(sex, 10)

--- a/man/r_na.Rd
+++ b/man/r_na.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/r_na.R
 \name{r_na}
 \alias{r_na}
-\title{Title}
+\title{Replace a Proportion of Values With NA}
 \usage{
 r_na(x, cols = -1, prob = 0.05)
 }
@@ -22,7 +22,7 @@ Returns a \code{\link[base]{data.frame}} or \code{\link[base]{list}}
 with random missing values.
 }
 \description{
-Description
+Replaces a proportion of values with NA. Useful for simulating missing data.
 }
 \examples{
 r_na(mtcars)


### PR DESCRIPTION
Minor fix.

- Documentation (Title and Description) for `r_na`
- Documentation (Title and Description) for `r_dummy`
- Minor typo.

Closes #15. 