### PR TITLE
Update age.R default age range

### DIFF
--- a/R/age.R
+++ b/R/age.R
@@ -1,19 +1,19 @@
 #' Generate Random Vector of Ages
 #'
-#' Generate a random vector of ages.
+#' Generate a random vector of ages within the provided range.  The default age range is set between 18 and 89, to match the age ranges whch appear (see e.g.,  https://gssdataexplorer.norc.org/variables/53/vshow)
 #'
 #' @inheritParams r_sample_factor
-#' @return Returns a random factor vector of gender elements.
+#' @return Returns a random integer vector of ages within the provided range (defaults to 18:89) 
 #' @keywords age
 #' @export
 #' @include utils.R r_sample.R
 #' @family variable functions
 #' @examples
-#' age(10)
-#' hist(age(10000))
+#' age(10) # draw 10 ages with default values
+#' hist(age(n=10000))  
 #' interval(age, 3, n = 1000)
 age <- hijack(r_sample,
     name = "Age",
-    x = 20:35
+    x = 18:89
 )
 


### PR DESCRIPTION
The default values before were 20 to 35.  The default values are buried in the documentation, so it took me a bit of wandering around to find out how and where they were set.  If there is not a specific reason to select 20 to 35 as the age range, I suggest expanding the default range to 18 to 89.  That is equally arbitrary, but it does have the advantage of matching the categories from the GSS.  That change was necessary for my own use case, and I think in general users may be expecting a bit of a larger range of ages here.