### PR TITLE
Adjust probs gender inclusive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ Collate: 'utils.R' 'r_sample.R' 'age.R' 'r_sample_factor.R' 'animal.R'
         'sex_inclusive.R' 'smokes.R' 'speed.R' 'state.R' 'string.R'
         'table_heat.R' 'time_stamp.R' 'upper.R' 'valid.R' 'variables.R'
         'varname.R' 'year.R' 'zip_code.R'
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/sex_inclusive.R
+++ b/R/sex_inclusive.R
@@ -10,9 +10,16 @@
 #'
 #' \tabular{lr}{
 #'   \bold{Gender}     \tab \bold{Percent}\cr
-#'   Male    \tab 51.07 \%\cr
-#'   Female  \tab 48.63 \%\cr
-#'   Trans*  \tab 0.30 \%\cr
+#'   Male    \tab 50.37 \%\cr
+#'   Female  \tab 47.93 \%\cr
+#'   Trans*  \tab 2 \%\cr
+#' }
+#' 
+#' \tabular{lr}{
+#'   \bold{Gender}     \tab \bold{Percent}\cr
+#'   Male    \tab 50.52 \%\cr
+#'   Female  \tab 48.08 \%\cr
+#'   Intersex  \tab 1.7 \%\cr
 #' }
 #'
 #' @inheritParams r_sample_factor
@@ -31,12 +38,14 @@
 #' barplot(table(gender_inclusive(10000)))
 sex_inclusive <- hijack(r_sample_factor,
                   name = "Sex",
-                  x = c("Male", "Female", "Intersex")
+                  x = c("Male", "Female", "Intersex"),
+                  prob = c(0.5052, 0.4808, 0.017)
 )
 
 #' @export
 #' @rdname sex_inclusive
 gender_inclusive <- hijack(r_sample_factor,
                 name = "Gender",
-                x = c("Male", "Female", "Trans*")
+                x = c("Male", "Female", "Trans*"),
+                prob = c(0.5037, 0.4793, 0.02)
 )

--- a/man/sex_inclusive.Rd
+++ b/man/sex_inclusive.Rd
@@ -8,14 +8,14 @@
 sex_inclusive(
   n,
   x = c("Male", "Female", "Intersex"),
-  prob = NULL,
+  prob = c(0.5052, 0.4808, 0.017),
   name = "Sex"
 )
 
 gender_inclusive(
   n,
   x = c("Male", "Female", "Trans*"),
-  prob = NULL,
+  prob = c(0.5037, 0.4793, 0.02),
   name = "Gender"
 )
 }
@@ -46,9 +46,16 @@ make-up:
 
 \tabular{lr}{
   \bold{Gender}     \tab \bold{Percent}\cr
-  Male    \tab 51.07 \%\cr
-  Female  \tab 48.63 \%\cr
-  Trans*  \tab 0.30 \%\cr
+  Male    \tab 50.37 \%\cr
+  Female  \tab 47.93 \%\cr
+  Trans*  \tab 2 \%\cr
+}
+
+\tabular{lr}{
+  \bold{Gender}     \tab \bold{Percent}\cr
+  Male    \tab 50.52 \%\cr
+  Female  \tab 48.08 \%\cr
+  Intersex  \tab 1.7 \%\cr
 }
 }
 \examples{


### PR DESCRIPTION
This PR is to address https://github.com/trinker/wakefield/issues/28

It does 3 things:

- Updates proportions tables of Male / Female / Trans to use 2% estimates that include non-binary individuals as well as folks who identify explicitly as transgender individuals.
- Adds proportions tables for Male / Female / Intersex using 1.7% estimates
- Updates the *_inclusive() functions to use these proportion tables.