### PR TITLE
Use `as_tibble()`

### DIFF
--- a/R/r_data_frame.R
+++ b/R/r_data_frame.R
@@ -98,7 +98,7 @@ function (n, ..., rep.sep = "_") {
 
     out <- stats::setNames(data.frame(out, stringsAsFactors = FALSE,
         check.names = FALSE), nms)
-    dplyr::tbl_df(out)
+    dplyr::as_tibble(out)
 }
 
 

--- a/R/r_dummy.R
+++ b/R/r_dummy.R
@@ -26,7 +26,7 @@ r_dummy <- function(fun, n, ..., prefix = FALSE, rep.sep = "_") {
 
     vect <- fun(n = n, ...)
 
-    out <- dplyr::tbl_df(mtabulate(vect))
+    out <- dplyr::as_tibble(mtabulate(vect))
 
     if (isTRUE(prefix)) {
         names(out) <- paste(attributes(vect)[["varname"]], colnames(out),

--- a/R/r_series.R
+++ b/R/r_series.R
@@ -118,7 +118,7 @@ r_series <- function(fun, j, n, ..., integer = FALSE, relate = NULL,
 
     names(out) <- paste(attributes(out[[1]])[["varname"]], seq_len(j),sep = rep.sep)
 
-    out <- seriesname(dplyr::tbl_df(as.data.frame(out)), attributes(out[[1]])[["varname"]])
+    out <- seriesname(dplyr::as_tibble(as.data.frame(out)), attributes(out[[1]])[["varname"]])
 
     if (isTRUE(integer)) out <- as_integer(out)
 

--- a/R/relate.R
+++ b/R/relate.R
@@ -67,6 +67,6 @@ relate <- function(x, j, name = NULL, operation = "+", mean = 5, sd = 1,
 
     out <- stats::setNames(seed_dat, paste(name, seq_len(j), sep = rep.sep))
 
-    seriesname(dplyr::tbl_df(out), name)
+    seriesname(dplyr::as_tibble(out), name)
 }
 


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

We've advanced our deprecation of `dplyr::as.tbl()` and `dplyr::tbl_df()`, both of which have been deprecated since dplyr 1.0.0 in 2020.

You'll need to update your package to use `tibble::as_tibble()` instead to stay on CRAN.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!